### PR TITLE
Fix locale setting in test scripts

### DIFF
--- a/doc/make_conformance_tables.sh
+++ b/doc/make_conformance_tables.sh
@@ -4,7 +4,7 @@ runpeaq() {
 	MODE=$1
 	CODFILE=$2
 	REFFILE=${CODFILE/cod/ref}
-	OUTPUT=`LANG=LC_ALL ${BASEDIR}/../src/peaq --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=${BASEDIR}/../src/.libs/libgstpeaq.so \
+	OUTPUT=`LC_ALL=C ${BASEDIR}/../src/peaq --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=${BASEDIR}/../src/.libs/libgstpeaq.so \
 		${MODE} "${REFFILE}" "$CODFILE"`
 	DI=`echo "$OUTPUT" | grep "Distortion Index:" | cut -d " " -f3`
 	DI_DELTA=`echo $DI - $3 | bc`

--- a/src/checkconformanceresults.sh
+++ b/src/checkconformanceresults.sh
@@ -22,7 +22,7 @@ docheck() {
 		CODFILE=${CONFORMANCEDATADIR}/${ITEMNAME}.wav
 		REFFILE=${CONFORMANCEDATADIR}/${ITEMNAME/cod/ref}.wav
 		REF_DI=${ITEM:8}
-		DI=`LANG=LC_ALL ${PEAQ} --${MODE} "${REFFILE}" "$CODFILE" | grep "Distortion Index:" | cut -d " " -f3`
+		DI=`LC_ALL=C ${PEAQ} --${MODE} "${REFFILE}" "$CODFILE" | grep "Distortion Index:" | cut -d " " -f3`
 		echo -n $ITEMNAME $DI $REF_DI
 		if [ x$DI = x$REF_DI ]; then
 			echo " OK"

--- a/src/runtest-1.0.sh
+++ b/src/runtest-1.0.sh
@@ -4,7 +4,7 @@ fi
 
 GSTLAUNCH=${GSTLAUNCH:-gst-launch-1.0}
 
-ODG=`LANG=LC_ALL $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
 	audiotestsrc name=src0 num-buffers=128 freq=440 \
 	tee \
 	queue name=queue0 \
@@ -18,7 +18,7 @@ echo $ODG
 if [ x$ODG != x0.171 ]; then
 	exit 1
 fi
-ODG=`LANG=LC_ALL $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
 	audiotestsrc name=src0 num-buffers=128 wave=saw freq=440 \
 	audiotestsrc name=src1 num-buffers=128 wave=triangle freq=440 \
 	peaq name=peaq \
@@ -28,7 +28,7 @@ echo $ODG
 if [ x$ODG != x-2.007 ]; then
 	exit 1
 fi
-ODG=`LANG=LC_ALL $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
 	audiotestsrc name=src0 num-buffers=128 wave=saw freq=440 \
 	audiotestsrc name=src1 num-buffers=128 wave=triangle freq=440 \
 	peaq name=peaq \
@@ -38,7 +38,7 @@ echo $ODG
 if [ x$ODG != x-2.007 ]; then
 	exit 1
 fi
-ODG=`LANG=LC_ALL $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C $GSTLAUNCH --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
 	audiotestsrc name=src0 num-buffers=128 wave=saw freq=440 \
 	audiotestsrc name=src1 num-buffers=128 wave=triangle freq=440 \
 	peaq name=peaq \


### PR DESCRIPTION
The tests need a locale that does not change the number format, so safest to set it to the standard `C` locale. Probably, I originally used `LANG=C` for that but then meant to switch to `LC_ALL=C`, as `LC_ALL` takes precedence. Instead, I apparently replaced the RHS with `LC_ALL`, resulting in the nonsensical `LANG=LC_ALL`. However, as long as `LC_ALL` was not set (to a locale with a non-standard number format), setting `LANG` sufficed and the unknown locale `LC_ALL` resulted in falling back to the standard, making this actually work in most cases and letting it go unnoticed for some 15 years! But now, it's time to finally fix it.