### PR TITLE
Let command line util `peaq` load the plugin statically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,6 @@ GST_API_VERSION=1.0
 gstreamer_1_0_packages="gstreamer-1.0 gstreamer-base-1.0 gstreamer-fft-1.0"
 PKG_CHECK_MODULES(PKGCONF, [$gstreamer_1_0_packages])
 AC_SUBST(GST_API_VERSION)
-PKG_CHECK_MODULES(PKGCONF_BIN, [gstreamer-$GST_API_VERSION])
 
 GST_SET_PLUGINDIR
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,9 +11,10 @@ libgstpeaq_la_SOURCES = gstpeaq.c gstpeaqplugin.c earmodel.c \
 libgstpeaq_la_CFLAGS = @PKGCONF_CFLAGS@
 libgstpeaq_la_LIBADD = @PKGCONF_LIBS@
 libgstpeaq_la_LDFLAGS = -module
-peaq_SOURCES = peaq.c
+peaq_SOURCES = peaq.c gstpeaq.c gstpeaqplugin.c earmodel.c \
+	leveladapter.c modpatt.c fftearmodel.c fbearmodel.c movaccum.c movs.c nn.c
 peaq_CFLAGS = @PKGCONF_CFLAGS@
-peaq_LDADD = @PKGCONF_BIN_LIBS@
+peaq_LDADD = @PKGCONF_LIBS@
 testpeaq_SOURCES = testpeaq.c earmodel.c leveladapter.c modpatt.c \
 		   fftearmodel.c fbearmodel.c movaccum.c
 testpeaq_CFLAGS = @PKGCONF_CFLAGS@

--- a/src/peaq.c
+++ b/src/peaq.c
@@ -24,6 +24,8 @@
 #include <glib/gprintf.h>
 #include <stdlib.h>
 
+#include <gst/gstplugin.h>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -80,6 +82,8 @@ static void on_pad_added(GstElement *element, GstPad *pad, gpointer data) {
     gst_pad_link(pad, sinkpad);
     gst_object_unref(sinkpad);
 }
+
+GST_PLUGIN_STATIC_DECLARE(peaq);
 
 int
 main(int argc, char *argv[])
@@ -152,9 +156,16 @@ main(int argc, char *argv[])
 
   peaq = gst_element_factory_make ("peaq", "peaq");
   if (!peaq) {
-    puts ("Error: peaq element could not be instantiated - is the plugin installed correctly?");
+    puts ("Warning: peaq plugin is not installed - registering statically");
+    GST_PLUGIN_STATIC_REGISTER(peaq);
+  }
+
+  peaq = gst_element_factory_make ("peaq", "peaq");
+  if (!peaq) {
+    puts ("Error: peaq element could not be instantiated");
     exit (2);
   }
+
   gst_object_ref_sink (peaq);
   g_object_set (G_OBJECT (peaq), "advanced", advanced,
                 "console_output", FALSE, NULL);

--- a/src/runtest-1.0.sh
+++ b/src/runtest-1.0.sh
@@ -49,14 +49,14 @@ if [ x$ODG != x-2.007 ]; then
 	exit 1
 fi
 
-ODG=`LC_ALL=C ./peaq --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C ./peaq --gst-disable-segtrap --gst-debug-level=2 \
 	${srcdir}/../test/stimulus_ref.flac ${srcdir}/../test/stimulus_test.wav \
 | grep "Objective Difference Grade:" | cut -d " " -f4`
 echo $ODG
 if [ x$ODG != x-1.077 ]; then
 	exit 1
 fi
-ODG=`LC_ALL=C ./peaq --gst-disable-segtrap --gst-debug-level=2 --gst-plugin-load=.libs/libgstpeaq.so \
+ODG=`LC_ALL=C ./peaq --gst-disable-segtrap --gst-debug-level=2 \
 	${srcdir}/../test/stimulus_test.wav ${srcdir}/../test/stimulus_ref.flac \
 | grep "Objective Difference Grade:" | cut -d " " -f4`
 echo $ODG

--- a/vs/peaq.vcxproj
+++ b/vs/peaq.vcxproj
@@ -53,21 +53,29 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-fft-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
     <Import Project="gstpeaq.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-fft-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
     <Import Project="gstpeaq.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-fft-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
     <Import Project="gstpeaq.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
+    <Import Project="$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-fft-1.0.props" Condition="exists('$(GSTREAMER_1_0_ROOT_MSVC_X86_64)\share\vs\2010\libs\gstreamer-base-1.0.props')" />
     <Import Project="gstpeaq.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -95,6 +103,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,6 +117,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -123,6 +133,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -140,6 +151,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,6 +162,16 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\earmodel.c" />
+    <ClCompile Include="..\src\fbearmodel.c" />
+    <ClCompile Include="..\src\fftearmodel.c" />
+    <ClCompile Include="..\src\gstpeaq.c" />
+    <ClCompile Include="..\src\gstpeaqplugin.c" />
+    <ClCompile Include="..\src\leveladapter.c" />
+    <ClCompile Include="..\src\modpatt.c" />
+    <ClCompile Include="..\src\movaccum.c" />
+    <ClCompile Include="..\src\movs.c" />
+    <ClCompile Include="..\src\nn.c" />
     <ClCompile Include="..\src\peaq.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vs/runtest-win32.ps1
+++ b/vs/runtest-win32.ps1
@@ -49,14 +49,14 @@ if ($ODG -ne -2.007) {
 }
 
 $ODG = [convert]::ToDouble(( `
-  Invoke-Expression ("$PSScriptRoot\win32\Release\peaq.exe --gst-plugin-load=$PSScriptRoot\win32\Release\gstpeaq.dll " + `
+  Invoke-Expression ("$PSScriptRoot\win32\Release\peaq.exe " + `
 	"$PSScriptRoot\..\test\stimulus_ref.flac $PSScriptRoot\..\test\stimulus_test.wav") `
  | Select-String -Pattern 'Objective Difference Grade: (.*)').Matches.Groups[1].Value)
 if ($ODG -ne -1.077) {
     throw "$ODG -ne -1.077"
 }
 $ODG = [convert]::ToDouble(( `
-  Invoke-Expression ("$PSScriptRoot\win32\Release\peaq.exe --gst-plugin-load=$PSScriptRoot\win32\Release\gstpeaq.dll " + `
+  Invoke-Expression ("$PSScriptRoot\win32\Release\peaq.exe " + `
 	"$PSScriptRoot\..\test\stimulus_test.wav $PSScriptRoot\..\test\stimulus_ref.flac ") `
  | Select-String -Pattern 'Objective Difference Grade: (.*)').Matches.Groups[1].Value)
 if ($ODG -ne -3.096) {

--- a/vs/runtest-x64.ps1
+++ b/vs/runtest-x64.ps1
@@ -49,14 +49,14 @@ if ($ODG -ne -2.007) {
 }
 
 $ODG = [convert]::ToDouble(( `
-  Invoke-Expression ("$PSScriptRoot\x64\Release\peaq.exe --gst-plugin-load=$PSScriptRoot\x64\Release\gstpeaq.dll " + `
+  Invoke-Expression ("$PSScriptRoot\x64\Release\peaq.exe " + `
 	"$PSScriptRoot\..\test\stimulus_ref.flac $PSScriptRoot\..\test\stimulus_test.wav") `
  | Select-String -Pattern 'Objective Difference Grade: (.*)').Matches.Groups[1].Value)
 if ($ODG -ne -1.077) {
     throw "$ODG -ne -1.077"
 }
 $ODG = [convert]::ToDouble(( `
-  Invoke-Expression ("$PSScriptRoot\x64\Release\peaq.exe --gst-plugin-load=$PSScriptRoot\x64\Release\gstpeaq.dll " + `
+  Invoke-Expression ("$PSScriptRoot\x64\Release\peaq.exe " + `
 	"$PSScriptRoot\..\test\stimulus_test.wav $PSScriptRoot\..\test\stimulus_ref.flac ") `
  | Select-String -Pattern 'Objective Difference Grade: (.*)').Matches.Groups[1].Value)
 if ($ODG -ne -3.096) {


### PR DESCRIPTION
Another excerpt from #24 thanks to @mincequi.

It should be noted that this causes a significant relative increase of the executable size (more than 4 times, depending on architecture), but it's still quite small, so should be ok. Alternatively, a compile-time option to select between dynamic and static linking might make sense.